### PR TITLE
Revert setting Bootstrap's keyboard property

### DIFF
--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -1191,7 +1191,7 @@
             this.getModalBody().append(this.createBodyContent());
             this.getModal().data('bs.modal', new BootstrapDialogModal(this.getModalForBootstrapDialogModal(), { //FIXME for BootstrapV4
                 backdrop: (this.isClosable() && this.canCloseByBackdrop()) ? true : 'static',
-                keyboard: this.options.closeByKeyboard,
+                keyboard: false,
                 show: false
             }));
             this.makeModalDraggable();


### PR DESCRIPTION
Reverts the change here: https://github.com/GedMarc/bootstrap4-dialog/commit/fc3c267a1fdf8eb3ae3301ee719604a8a7334680

Because:
1. It's already implemented by handling keyup.
2. It doesn't handle other cases such as a non-closable dialog.
3. It cannot be changed dynamically.