### PR TITLE
Improved draggable option for Firefox

### DIFF
--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -1153,6 +1153,7 @@
         makeModalDraggable: function () {
             if (this.options.draggable) {
                 this.getModalHeader().addClass(this.getNamespace('draggable')).on('mousedown', { dialog: this }, function (event) {
+                    event.preventDefault();
                     var dialog = event.data.dialog;
                     dialog.draggableData.isMouseDown = true;
                     var dialogOffset = dialog.getModalDialog().offset();
@@ -1169,7 +1170,6 @@
                     if (!dialog.draggableData.isMouseDown) {
                         return;
                     }
-                    event.preventDefault();
                     dialog.getModalDialog().offset({
                         top: event.clientY - dialog.draggableData.mouseOffset.top,
                         left: event.clientX - dialog.draggableData.mouseOffset.left


### PR DESCRIPTION
A follow-up for https://github.com/GedMarc/bootstrap4-dialog/pull/31 which fixes the issue for Firefox. The previous fix only worked for Chromium.